### PR TITLE
remove template variable "iteration_current" to fix gcc 7.3.0 compile…

### DIFF
--- a/source/aatc_templatemagic.hpp
+++ b/source/aatc_templatemagic.hpp
@@ -94,7 +94,7 @@ namespace aatc {
 					int iteration_start,
 					int iteration_end,
 					int iteration_current,
-					template<int iteration_current> class functor_operate,
+					template<int > class functor_operate,
 					typename T_arg1
 				> class internal_functor {
 				public:
@@ -107,7 +107,7 @@ namespace aatc {
 				template<
 					int iteration_start,
 					int iteration_end,
-					template<int iteration_current> class functor_operate,
+					template<int > class functor_operate,
 					typename T_arg1
 				> class internal_functor<iteration_start, iteration_end, -1, functor_operate, T_arg1> {
 				public:
@@ -139,7 +139,7 @@ namespace aatc {
 					int iteration_start,
 					int iteration_end,
 					int iteration_current,
-					template<int iteration_current> class functor_operate,
+					template<int > class functor_operate,
 					typename T_arg1,
 					typename T_arg2
 				> struct internal_functor {


### PR DESCRIPTION
… error under Kubuntu 18.04
aatc would not compile in Code::Blocks using gcc 7.3.0 without this change. After the change it compiles and runs (I am using the map container primarily). The original issue that gcc complains about appears to be that the template parameter "iteration_current" hides the variable with the same name in the outer scope.
Thanks for the great library!